### PR TITLE
Core: update webpack config to generate the bundle in the lib directory

### DIFF
--- a/core/.gitignore
+++ b/core/.gitignore
@@ -1,5 +1,8 @@
 .DS_Store
 node_modules/*
+lib/*
+*.tgz
 dist/index_bundle.js
 dist/index_bundle.js.map
 npm-debug.log
+.yarn-error.log

--- a/core/.npmignore
+++ b/core/.npmignore
@@ -1,5 +1,4 @@
-app.js
-.babelrc
-webpack.config.js
-test/*
-dist/*
+*
+!lib/**/*
+!package.json
+!*.md

--- a/core/package.json
+++ b/core/package.json
@@ -2,7 +2,7 @@
   "name": "presto-ui",
   "version": "v0.2.2",
   "description": "Javascript framework for building platform independent apps.",
-  "main": "index.js",
+  "main": "lib/index.js",
   "dependencies": {},
   "devDependencies": {
     "babel-core": "^6.9.1",
@@ -11,13 +11,13 @@
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-0": "^6.5.0",
-    "webpack": "^1.13.1",
-    "webpack-dev-server": "^1.14.0"
+    "ramda": "latest",
+    "axios": "latest",
+    "webpack": "^1.13.1"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "compile": "webpack -p --progress --colors --watch",
-    "start": "webpack-dev-server --inline --watch --hot --host 0.0.0.0 --content-base dist/"
+    "compile": "webpack -p --progress --colors"
   },
   "repository": {
     "type": "git",

--- a/core/webpack.config.js
+++ b/core/webpack.config.js
@@ -24,13 +24,10 @@
 */
 
 module.exports = {
-	devtool: "source-map",
-	entry: ["./demo/index.js"],
+	entry: "./index.js",
   output: {
-    path: __dirname + "/dist",
-    filename: "index_bundle.js",
-    publicPath: '/dist/',
-    sourceMapFilename: "index_bundle.js.map"
+    filename: "lib/index.js",
+    libraryTarget: 'commonjs2'
   },
   module: {
     loaders: [


### PR DESCRIPTION
presto-ui will be served from lib/index.js to avoid complete source code download on package install.